### PR TITLE
Fix: Run job when PR merge

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,10 +23,10 @@ jobs:
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: read
-    if: ${{ github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'feature') || contains(github.event.pull_request.labels.*.name, 'bug') || contains(github.event.pull_request.labels.*.name, 'chore') }}
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - if: ${{ github.event.pull_request.merged }}
+        run: |
           TAG_NAME=$(ruby -e 'print "release-#{Time.now.getlocal("+09:00").strftime("%Y-%m-%d-%H%M%S_%3N")}"')
           echo "tag_name=$TAG_NAME" >> $GITHUB_ENV
       # (Optional) GitHub Enterprise requires GHE_HOST variable set


### PR DESCRIPTION
## Why

<!--- Tại sao? lại mở PR này -->

Fixes: https://github.com/learnforward2023/project-web/issues/7

## What

<!--- Tóm tắt các thay đổi có trong PR. -->

- [Fix: Run job when PR merge](https://github.com/learnforward2023/project-web/commit/c412c50f1d7d4c2381134926c032f6a470ce0a18)

## Other Information

<!--- Ghi thêm các thông tin liên quan đến PR này, và các hình ảnh nếu có -->

Ah, chỉ cần chạy Jobs khi merged thôi!
